### PR TITLE
Update nostr-relay-config.yml

### DIFF
--- a/nostr-relay/nostr-relay-config.yml
+++ b/nostr-relay/nostr-relay-config.yml
@@ -1,6 +1,7 @@
 DEBUG: false
 
-db_filename: ../nostr-relay/nostr.sqlite3
+storage:
+  sqlalchemy.url: sqlite+aiosqlite:///path/to/db.sqlite3
 
 relay_name: python relay
 relay_description: relay written in python


### PR DESCRIPTION
there is a warning message from sqlite that recommends making that change. after replacing that url with the new one, the warning message dissapears